### PR TITLE
upload test-suite.log if make check fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         timeout-minutes: 20
         run: make check
       - name: upload logs
-        uses: actions/checkout@v1
+        uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: test-suite.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
       - name: make check
         timeout-minutes: 20
         run: make check
+      - name: upload logs
+        uses: actions/checkout@v1
+        if: failure()
+        with:
+          name: test-suite.log
+          path: src/test-suite.log
 
   x86_64-w64-mingw32:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
         timeout-minutes: 20
         run: make check
       - name: upload logs
-        uses: actions/checkout@v1
+        uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: test-suite.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,12 @@ jobs:
       - name: make check
         timeout-minutes: 20
         run: make check
+      - name: upload logs
+        uses: actions/checkout@v1
+        if: failure()
+        with:
+          name: test-suite.log
+          path: src/test-suite.log
       - name: Collect coverage
         run: |
           lcov -c -d src -o cov.info


### PR DESCRIPTION
If make check fails, we should see an artifact with the test-suite.log for more details.