### PR TITLE
update altintegration.mk to check for host and set mingw32 compiler a…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,6 @@ jobs:
         run: PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g')
       - name: set variables and build dependencies for x86_64-w64
         env:
-          CC: x86_64-w64-mingw32-gcc
-          CXX: x86_64-w64-mingw32-g++
           HOST: x86_64-w64-mingw32
           BASE_CACHE: ~/.depends_cache
         run: cd depends && make -j2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,8 +110,6 @@ jobs:
         run: PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g')
       - name: set variables and build dependencies for x86_64-w64
         env:
-          CC: x86_64-w64-mingw32-gcc
-          CXX: x86_64-w64-mingw32-g++
           HOST: x86_64-w64-mingw32
         run: cd depends && make -j2
       - name: autogen

--- a/depends/packages/altintegration.mk
+++ b/depends/packages/altintegration.mk
@@ -4,9 +4,15 @@ $(package)_download_path=https://github.com/VeriBlock/alt-integration-cpp/archiv
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=9c2288e48a47ecb1c9d94c36f3acabffb91718d9c366110c52785563e4d0a355
 
-define $(package)_config_cmds
-  cmake -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DWITH_ROCKSDB=OFF -DSHARED=OFF -B .
-endef
+ifeq ($(HOST), x86_64-w64-mingw32)
+  define $(package)_config_cmds
+    cmake -DCMAKE_C_COMPILER=$(HOST)-gcc -DCMAKE_CXX_COMPILER=$(HOST)-g++ -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DWITH_ROCKSDB=OFF -DSHARED=OFF -B .
+  endef
+else
+  define $(package)_config_cmds
+    cmake -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DWITH_ROCKSDB=OFF -DSHARED=OFF -B .
+  endef
+endif
 
 define $(package)_build_cmds
   $(MAKE)

--- a/depends/packages/altintegration.mk
+++ b/depends/packages/altintegration.mk
@@ -4,13 +4,15 @@ $(package)_download_path=https://github.com/VeriBlock/alt-integration-cpp/archiv
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=9c2288e48a47ecb1c9d94c36f3acabffb91718d9c366110c52785563e4d0a355
 
-define $(package)_config_cmds
-  ifeq ($(HOST), x86_64-w64-mingw32)
+ifeq ($(HOST), x86_64-w64-mingw32)
+  define $(package)_config_cmds
     cmake -DCMAKE_C_COMPILER=$(HOST)-gcc -DCMAKE_CXX_COMPILER=$(HOST)-g++ -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DWITH_ROCKSDB=OFF -DSHARED=OFF -B .
-  else
+  endef
+else
+  define $(package)_config_cmds
     cmake -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DWITH_ROCKSDB=OFF -DSHARED=OFF -B .
-  endif
-endef
+  endef
+endif
 
 define $(package)_build_cmds
   $(MAKE)

--- a/depends/packages/altintegration.mk
+++ b/depends/packages/altintegration.mk
@@ -4,15 +4,13 @@ $(package)_download_path=https://github.com/VeriBlock/alt-integration-cpp/archiv
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=9c2288e48a47ecb1c9d94c36f3acabffb91718d9c366110c52785563e4d0a355
 
-ifeq ($(HOST), x86_64-w64-mingw32)
-  define $(package)_config_cmds
+define $(package)_config_cmds
+  ifeq ($(HOST), x86_64-w64-mingw32)
     cmake -DCMAKE_C_COMPILER=$(HOST)-gcc -DCMAKE_CXX_COMPILER=$(HOST)-g++ -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DWITH_ROCKSDB=OFF -DSHARED=OFF -B .
-  endef
-else
-  define $(package)_config_cmds
+  else
     cmake -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DWITH_ROCKSDB=OFF -DSHARED=OFF -B .
-  endef
-endif
+  endif
+endef
 
 define $(package)_build_cmds
   $(MAKE)


### PR DESCRIPTION
We need to compile alt-integration-cpp with the mingw32 compiler for cross compilation, however, when we set CC and CXX globally, after the user runs the install, they will have to manually change their defaults back to gcc/g++.  With this, the Makefile will look at the HOST variable, and set the appropriate compiler, thus making it possible to leave the system variables of CC and CXX unchanged.