### PR TITLE
BFI Update

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -716,12 +716,11 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_BFI">
        
-	    <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_BFI">
-         <item>
+	<item>
           <widget class="QLabel" name="bfiInfoLabel">
            <property name="toolTip">
-            <string>........ This is the data tool tip </string>
+            <string>Bitcoin Finality Indicator (BFI) indicates when a transaction on an altchain network has as much
+            security as a transaction on Bitcoin itself.</string>
            </property>
            <property name="text">
             <string>Bitcoin Finality Indicator (BFI) indicates when a transaction on an altchain network has as much
@@ -758,8 +757,6 @@
         </spacer>
        </item>
       </layout>
-	  </item>
-	  </layout>
      </widget>
      
     </widget>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -151,7 +151,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         ///////////////////////////////////////////////
         // VBK NETWORK
 
-        std::string stdVbkEndPoint = gArgs.GetArg("bfiendpoint", "");// read from conf.
+        std::string stdVbkEndPoint = gArgs.GetArg("-bfiendpoint", "");// read from conf.
         
         QString vbkEndPoint = QString::fromStdString(stdVbkEndPoint);
         QString url = vbkEndPoint;  
@@ -180,7 +180,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         
         if (reply->error()) {            
             err = true;
-            vbkMessage = "BFI not setup yet, specify url in vbitcoin.conf";
+            vbkMessage = "BFI not setup yet, specify -bfiendpoint=url in vbitcoin.conf";
         } else {
             QByteArray buffer = reply->readAll();
             dataLine = buffer.constData();


### PR DESCRIPTION
This should fix the formatting and display of the Bitcoin Finality Indicator as well as make some of the labels easier for users to understand as per ALT-8 and ALT-9