### PR TITLE
Add POP enabled checks

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -45,6 +45,7 @@ static void SetupCliArgs()
     const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
     const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
+    const auto detregtestBaseParams = CreateBaseChainParams(CBaseChainParams::DETREGTEST);
 
     gArgs.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -56,7 +57,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-rpcconnect=<ip>", strprintf("Send commands to node running on <ip> (default: %s)", DEFAULT_RPCCONNECT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-rpcport=<port>", strprintf("Connect to JSON-RPC on <port> (default: %u, testnet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-rpcport=<port>", strprintf("Connect to JSON-RPC on <port> (default: %u, testnet: %u, regtest: %u, detregtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), regtestBaseParams->RPCPort(), detregtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwait", "Wait for RPC server to start", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to vbitcoind). This changes the RPC endpoint used, e.g. http://127.0.0.1:8332/wallet/<walletname>", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -156,6 +156,20 @@ public:
 };
 
 /**
+ * Deterministic regression test
+ */
+class CDetRegTestParams : public CChainParams
+{
+public:
+    explicit CDetRegTestParams(const ArgsManager& args);
+    /**
+     * Allows modifying the Version Bits detregtest parameters.
+     */
+    void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
+    void UpdateActivationParametersFromArgs(const ArgsManager& args);
+};
+
+/**
  * Creates and returns a std::unique_ptr<CChainParams> of the chosen chain.
  * @returns a CChainParams* of the chosen chain.
  * @throws a std::runtime_error if the chain is not supported.

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -14,10 +14,13 @@
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
+const std::string CBaseChainParams::DETREGTEST = "detregtest";
 
 void SetupChainParamsBaseOptions()
 {
-    gArgs.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Allowed values: main, test, regtest", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Allowed values: main, test, regtest, detregtest", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-detregtest", "Enter deterministic regression test mode, which uses a special chain in which blocks can be solved instantly and deterministically. "
+                 "This is intended for regression testing tools and app development. Equivalent to -chain=detregtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                  "This is intended for regression testing tools and app development. Equivalent to -chain=regtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-segwitheight=<n>", "Set the activation height of segwit. -1 to disable. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
@@ -41,6 +44,8 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
         return MakeUnique<CBaseChainParams>("testnet3", 18332);
     else if (chain == CBaseChainParams::REGTEST)
         return MakeUnique<CBaseChainParams>("regtest", 18443);
+    else if (chain == CBaseChainParams::DETREGTEST)
+        return MakeUnique<CBaseChainParams>("detregtest", 18554);
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -20,6 +20,7 @@ public:
     static const std::string MAIN;
     static const std::string TESTNET;
     static const std::string REGTEST;
+    static const std::string DETREGTEST;
     ///@}
 
     const std::string& DataDir() const { return strDataDir; }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -352,9 +352,11 @@ void SetupServerArgs()
     const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
     const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
+    const auto detregtestBaseParams = CreateBaseChainParams(CBaseChainParams::DETREGTEST);
     const auto defaultChainParams = CreateChainParams(CBaseChainParams::MAIN);
     const auto testnetChainParams = CreateChainParams(CBaseChainParams::TESTNET);
     const auto regtestChainParams = CreateChainParams(CBaseChainParams::REGTEST);
+    const auto detregtestChainParams = CreateChainParams(CBaseChainParams::DETREGTEST);
 
     // Hidden Options
     std::vector<std::string> hidden_args = {
@@ -430,7 +432,7 @@ void SetupServerArgs()
     gArgs.AddArg("-onlynet=<net>", "Make outgoing connections only through network <net> (ipv4, ipv6 or onion). Incoming connections are not affected by this option. This option can be specified multiple times to allow multiple networks.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-peerbloomfilters", strprintf("Support filtering of blocks and transaction with bloom filters (default: %u)", DEFAULT_PEERBLOOMFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-permitbaremultisig", strprintf("Relay non-P2SH multisig (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-port=<port>", strprintf("Listen for connections on <port> (default: %u, testnet: %u, regtest: %u)", defaultChainParams->GetDefaultPort(), testnetChainParams->GetDefaultPort(), regtestChainParams->GetDefaultPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-port=<port>", strprintf("Listen for connections on <port> (default: %u, testnet: %u, regtest: %u, detregtest: %u)", defaultChainParams->GetDefaultPort(), testnetChainParams->GetDefaultPort(), regtestChainParams->GetDefaultPort(), detregtestChainParams->GetDefaultPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-proxy=<ip:port>", "Connect through SOCKS5 proxy, set -noproxy to disable (default: disabled)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-proxyrandomize", strprintf("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)", DEFAULT_PROXYRANDOMIZE), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-seednode=<ip>", "Connect to a node to retrieve peer addresses, and disconnect. This option can be specified multiple times to connect to multiple nodes.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -541,7 +543,7 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcbind=<addr>[:port]", "Bind to given address to listen for JSON-RPC connections. Do not expose the RPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
-    gArgs.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u, testnet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u, testnet: %u, regtest: %u, detregtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), regtestBaseParams->RPCPort(), detregtestBaseParams->RPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcserialversion", strprintf("Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)", DEFAULT_RPC_SERIALIZE_VERSION), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcthreads=<n>", strprintf("Set the number of threads to service RPC calls (default: %d)", DEFAULT_HTTP_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1842,7 +1842,7 @@ bool AppInitMain(NodeContext& node)
         banman->DumpBanlist();
     }, DUMP_BANS_INTERVAL * 1000);
 
-    {
+    if (VeriBlock::isPopEnabled()) {
         auto& pop = VeriBlock::GetPop();
         auto* tip = ChainActive().Tip();
         altintegration::ValidationState state;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -143,7 +143,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     addPackageTxs<ancestor_score>(nPackagesSelected, nDescendantsUpdated);
 
     // VeriBlock: add PopData into the block
-    if (chainparams.isPopActive(nHeight))
+    if (VeriBlock::isPopEnabled() && chainparams.isPopActive(nHeight))
     {
         pblock->popData = VeriBlock::getPopData(*pindexPrev);
     }
@@ -166,7 +166,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams);
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
 
-    VeriBlock::addPopPayoutsIntoCoinbaseTx(coinbaseTx, *pindexPrev, chainparams);
+    if (VeriBlock::isPopEnabled()) {
+        VeriBlock::addPopPayoutsIntoCoinbaseTx(coinbaseTx, *pindexPrev, chainparams);
+    }
 
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
     pblocktemplate->vchCoinbaseCommitment = GenerateCoinbaseCommitment(*pblock, pindexPrev, chainparams.GetConsensus());

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,6 +30,7 @@
 #include <util/strencodings.h>
 #include <util/validation.h>
 #include <vbk/p2p_sync.hpp>
+#include <vbk/pop_service.hpp>
 
 #include <memory>
 
@@ -1926,11 +1927,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     }
 
     // VeriBlock: if POP is not enabled, ignore POP-related P2P calls
-    int tipHeight = ChainActive().Height();
-    if (Params().isPopActive(tipHeight)) {
-        int pop_res = VeriBlock::p2p::processPopData(pfrom, strCommand, vRecv, connman);
-        if (pop_res >= 0) {
-            return pop_res;
+    if (VeriBlock::isPopEnabled()) {
+        int tipHeight = ChainActive().Height();
+        if (Params().isPopActive(tipHeight)) {
+            int pop_res = VeriBlock::p2p::processPopData(pfrom, strCommand, vRecv, connman);
+            if (pop_res >= 0) {
+                return pop_res;
+            }
         }
     }
 
@@ -3991,7 +3994,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
             connman->PushMessage(pto, msgMaker.Make(NetMsgType::INV, vInv));
 
         // VeriBlock offer Pop Data
-        {
+        if (VeriBlock::isPopEnabled()) {
             VeriBlock::p2p::offerPopData<altintegration::ATV>(pto, connman, msgMaker);
             VeriBlock::p2p::offerPopData<altintegration::VTB>(pto, connman, msgMaker);
             VeriBlock::p2p::offerPopData<altintegration::VbkBlock>(pto, connman, msgMaker);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -46,6 +46,7 @@
 
 #include <vbk/adaptors/univalue_json.hpp>
 #include <vbk/pop_common.hpp>
+#include <vbk/pop_service.hpp>
 
 struct CUpdatedBlock
 {
@@ -922,7 +923,7 @@ static UniValue getblock(const JSONRPCRequest& request)
 
     UniValue json = blockToJSON(block, tip, pblockindex, verbosity >= 2);
 
-    {
+    if (VeriBlock::isPopEnabled()) {
         auto& pop = VeriBlock::GetPop();
         LOCK(cs_main);
         auto index = pop.getAltBlockTree().getBlockIndex(block.GetHash().asVector());

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -732,25 +732,28 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
         result.pushKV("default_witness_commitment", HexStr(pblocktemplate->vchCoinbaseCommitment.begin(), pblocktemplate->vchCoinbaseCommitment.end()));
     }
 
-    //VeriBlock Data
-    const auto popDataRoot = pblock->popData.getMerkleRoot();
-    result.pushKV("pop_data_root", HexStr(popDataRoot.begin(), popDataRoot.end()));
-    result.pushKV("pop_data", altintegration::ToJSON<UniValue>(pblock->popData, /*verbose=*/true));
-    using altintegration::ContextInfoContainer;
-    auto ctx = ContextInfoContainer::createFromPrevious(VeriBlock::GetAltBlockIndex(pindexPrev), VeriBlock::GetPop().getConfig().getAltParams());
-    result.pushKV("pop_first_previous_keystone", HexStr(ctx.keystones.firstPreviousKeystone));
-    result.pushKV("pop_second_previous_keystone", HexStr(ctx.keystones.secondPreviousKeystone));
+    if (VeriBlock::isPopEnabled()) {
+        //VeriBlock Data
+        const auto popDataRoot = pblock->popData.getMerkleRoot();
+        result.pushKV("pop_data_root", HexStr(popDataRoot.begin(), popDataRoot.end()));
+        result.pushKV("pop_data", altintegration::ToJSON<UniValue>(pblock->popData, /*verbose=*/true));
+        using altintegration::ContextInfoContainer;
+        auto ctx = ContextInfoContainer::createFromPrevious(VeriBlock::GetAltBlockIndex(pindexPrev),
+                                                            VeriBlock::GetPop().getConfig().getAltParams());
+        result.pushKV("pop_first_previous_keystone", HexStr(ctx.keystones.firstPreviousKeystone));
+        result.pushKV("pop_second_previous_keystone", HexStr(ctx.keystones.secondPreviousKeystone));
 
-    // pop rewards
-    UniValue popRewardsArray(UniValue::VARR);
-    VeriBlock::PoPRewards popRewards = VeriBlock::getPopRewards(*pindexPrev, Params());
-    for (const auto& itr : popRewards) {
-        UniValue popRewardValue(UniValue::VOBJ);
-        popRewardValue.pushKV("payout_info", HexStr(itr.first.begin(), itr.first.end()));
-        popRewardValue.pushKV("amount", itr.second);
-        popRewardsArray.push_back(popRewardValue);
+        // pop rewards
+        UniValue popRewardsArray(UniValue::VARR);
+        VeriBlock::PoPRewards popRewards = VeriBlock::getPopRewards(*pindexPrev, Params());
+        for (const auto& itr : popRewards) {
+            UniValue popRewardValue(UniValue::VOBJ);
+            popRewardValue.pushKV("payout_info", HexStr(itr.first.begin(), itr.first.end()));
+            popRewardValue.pushKV("amount", itr.second);
+            popRewardsArray.push_back(popRewardValue);
+        }
+        result.pushKV("pop_rewards", popRewardsArray);
     }
-    result.pushKV("pop_rewards", popRewardsArray);
 
     return result;
 }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1100,7 +1100,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "f0b3a3c29869edc765d579c928f7f1690a71fbb673b49ccf39cbc4de18156a0d");
+    BOOST_CHECK_EQUAL(out_sha_hex, "692ab186014a67ed1bcdf4258e1787acbfa5aa9276f5b95f5e2bb7adc6f628a0");
 }
 
 BOOST_AUTO_TEST_CASE(util_FormatMoney)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -233,8 +233,10 @@ bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockF
         batch.Write(std::make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash()), CDiskBlockIndex(*it));
     }
 
-    // write BTC/VBK/ALT blocks
-    VeriBlock::saveTrees(&batch);
+    if (VeriBlock::isPopEnabled()) {
+        // write BTC/VBK/ALT blocks
+        VeriBlock::saveTrees(&batch);
+    }
     return WriteBatch(batch, true);
 }
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -255,6 +255,7 @@ const std::list<SectionInfo> ArgsManager::GetUnrecognizedSections() const
 {
     // Section names to be recognized in the config file.
     static const std::set<std::string> available_sections{
+        CBaseChainParams::DETREGTEST,
         CBaseChainParams::REGTEST,
         CBaseChainParams::TESTNET,
         CBaseChainParams::MAIN
@@ -833,13 +834,16 @@ std::string ArgsManager::GetChainName() const
         return value.isNull() ? false : value.isBool() ? value.get_bool() : InterpretBool(value.get_str());
     };
 
+    const bool fDetRegTest = get_net("-detregtest");
     const bool fRegTest = get_net("-regtest");
     const bool fTestNet = get_net("-testnet");
     const bool is_chain_arg_set = IsArgSet("-chain");
 
-    if ((int)is_chain_arg_set + (int)fRegTest + (int)fTestNet > 1) {
-        throw std::runtime_error("Invalid combination of -regtest, -testnet and -chain. Can use at most one.");
+    if ((int)is_chain_arg_set + (int)fRegTest + (int)fTestNet + (int)fDetRegTest > 1) {
+        throw std::runtime_error("Invalid combination of -detregtest, -regtest, -testnet and -chain. Can use at most one.");
     }
+    if (fDetRegTest)
+        return CBaseChainParams::DETREGTEST;
     if (fRegTest)
         return CBaseChainParams::REGTEST;
     if (fTestNet)

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -15,6 +15,8 @@
 #include <ctime>
 #include <tinyformat.h>
 
+#include <veriblock/pop/time.hpp>
+
 static std::atomic<int64_t> nMockTime(0); //!< For unit testing
 
 int64_t GetTime()
@@ -44,6 +46,7 @@ template std::chrono::microseconds GetTime();
 void SetMockTime(int64_t nMockTimeIn)
 {
     nMockTime.store(nMockTimeIn, std::memory_order_relaxed);
+    altintegration::setMockTime(nMockTimeIn);
 }
 
 int64_t GetMockTime()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1212,9 +1212,12 @@ CAmount GetBlockSubsidy(int nHeight, const CChainParams& params)
         return 0;
 
     CAmount nSubsidy = 50 * COIN;
-    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
-    nSubsidy = VeriBlock::getCoinbaseSubsidy(nSubsidy, nHeight, params);
 
+    if (VeriBlock::isPopEnabled()) {
+        nSubsidy = VeriBlock::getCoinbaseSubsidy(nSubsidy, nHeight, params);
+    }
+
+    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
     nSubsidy >>= halvings;
     return nSubsidy;
 }
@@ -1392,9 +1395,11 @@ void CChainState::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationSt
     if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
         pindex->nStatus |= BLOCK_FAILED_VALID;
 
-        VeriBlock::GetPop()
-            .getAltBlockTree()
-            .invalidateSubtree(pindex->GetBlockHash().asVector(), altintegration::BLOCK_FAILED_BLOCK);
+        if (VeriBlock::isPopEnabled()) {
+            VeriBlock::GetPop()
+                    .getAltBlockTree()
+                    .invalidateSubtree(pindex->GetBlockHash().asVector(), altintegration::BLOCK_FAILED_BLOCK);
+        }
 
         m_blockman.m_failed_blocks.insert(pindex);
         setDirtyBlockIndex.insert(pindex);
@@ -1710,8 +1715,10 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     }
 
     auto prevHash = pindex->pprev->GetBlockHash();
-    altintegration::ValidationState state;
-    VeriBlock::setState(prevHash, state);
+    if (VeriBlock::isPopEnabled()) {
+        altintegration::ValidationState state;
+        VeriBlock::setState(prevHash, state);
+    }
 
     // move best block pointer to prevout block
     view.SetBestBlock(prevHash);
@@ -2142,14 +2149,18 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     nTimeConnect += nTime3 - nTime2;
     LogPrint(BCLog::BENCH, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(), MILLI * (nTime3 - nTime2), MILLI * (nTime3 - nTime2) / block.vtx.size(), nInputs <= 1 ? 0 : MILLI * (nTime3 - nTime2) / (nInputs - 1), nTimeConnect * MICRO, nTimeConnect * MILLI / nBlocksTotal);
 
-    assert(pindex->pprev && "previous block ptr is nullptr");
-    if (!VeriBlock::checkCoinbaseTxWithPopRewards(*block.vtx[0], nFees, *pindex, chainparams, state)) {
-        return false;
-    }
+    if (VeriBlock::isPopEnabled()) {
+        assert(pindex->pprev && "previous block ptr is nullptr");
+        if (!VeriBlock::checkCoinbaseTxWithPopRewards(*block.vtx[0], nFees, *pindex, chainparams, state)) {
+            return false;
+        }
 
-    altintegration::ValidationState _state;
-    if (!VeriBlock::setState(pindex->GetBlockHash(), _state)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-block-pop", strprintf("Block %s is POP invalid: %s", pindex->GetBlockHash().ToString(), _state.toString()));
+        altintegration::ValidationState _state;
+        if (!VeriBlock::setState(pindex->GetBlockHash(), _state)) {
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-block-pop",
+                                 strprintf("Block %s is POP invalid: %s", pindex->GetBlockHash().ToString(),
+                                           _state.toString()));
+        }
     }
 
     if (!control.Wait()) {
@@ -2368,9 +2379,11 @@ void static UpdateTip(const CBlockIndex* pindexNew, const CChainParams& chainPar
         g_best_block = pindexNew->GetBlockHash();
         g_best_block_cv.notify_all();
     }
-    altintegration::ValidationState state;
-    bool ret = VeriBlock::setState(pindexNew->GetBlockHash(), state);
-    assert(ret && "block has been checked previously and should be valid");
+    if (VeriBlock::isPopEnabled()) {
+        altintegration::ValidationState state;
+        bool ret = VeriBlock::setState(pindexNew->GetBlockHash(), state);
+        assert(ret && "block has been checked previously and should be valid");
+    }
 
     std::string warningMessages;
     if (!::ChainstateActive().IsInitialBlockDownload()) {
@@ -2401,19 +2414,24 @@ void static UpdateTip(const CBlockIndex* pindexNew, const CChainParams& chainPar
             AppendWarning(warningMessages, strprintf(_("%d of last 100 blocks have unexpected version").translated, nUpgraded));
     }
 
-    auto& pop = VeriBlock::GetPop();
-    auto* vbktip = pop.getVbkBlockTree().getBestChain().tip();
-    auto* btctip = pop.getBtcBlockTree().getBestChain().tip();
-    LogPrintf("%s: new best=ALT:%d:%s %s %s version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
-        pindexNew->nHeight,
-        pindexNew->GetBlockHash().GetHex(),
-        (vbktip ? vbktip->toShortPrettyString() : "VBK:nullptr"),
-        (btctip ? btctip->toShortPrettyString() : "BTC:nullptr"),
-        pindexNew->nVersion,
-        log(pindexNew->nChainWork.getdouble()) / log(2.0), (unsigned long)pindexNew->nChainTx,
-        FormatISO8601DateTime(pindexNew->GetBlockTime()),
-        GuessVerificationProgress(chainParams.TxData(), pindexNew), ::ChainstateActive().CoinsTip().DynamicMemoryUsage() * (1.0 / (1 << 20)), ::ChainstateActive().CoinsTip().GetCacheSize(),
-        !warningMessages.empty() ? strprintf(" warning='%s'", warningMessages) : "");
+    if (VeriBlock::isPopEnabled()) {
+        auto& pop = VeriBlock::GetPop();
+        auto* vbktip = pop.getVbkBlockTree().getBestChain().tip();
+        auto* btctip = pop.getBtcBlockTree().getBestChain().tip();
+        LogPrintf("%s: new best=ALT:%d:%s %s %s version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+            __func__,
+            pindexNew->nHeight,
+            pindexNew->GetBlockHash().GetHex(),
+            (vbktip ? vbktip->toShortPrettyString() : "VBK:nullptr"),
+            (btctip ? btctip->toShortPrettyString() : "BTC:nullptr"),
+            pindexNew->nVersion,
+            log(pindexNew->nChainWork.getdouble()) / log(2.0), (unsigned long) pindexNew->nChainTx,
+            FormatISO8601DateTime(pindexNew->GetBlockTime()),
+            GuessVerificationProgress(chainParams.TxData(), pindexNew),
+            ::ChainstateActive().CoinsTip().DynamicMemoryUsage() * (1.0 / (1 << 20)),
+            ::ChainstateActive().CoinsTip().GetCacheSize(),
+            !warningMessages.empty() ? strprintf(" warning='%s'", warningMessages) : "");
+    }
 }
 
 /** Disconnect m_chain's tip.
@@ -2464,7 +2482,9 @@ bool CChainState::DisconnectTip(BlockValidationState& state, const CChainParams&
     }
 
     // VeriBlock
-    VeriBlock::addDisconnectedPopdata(block.popData);
+    if (VeriBlock::isPopEnabled()) {
+        VeriBlock::addDisconnectedPopdata(block.popData);
+    }
 
     m_chain.SetTip(pindexDelete->pprev);
 
@@ -2602,9 +2622,10 @@ bool CChainState::ConnectTip(BlockValidationState& state, const CChainParams& ch
     mempool.removeForBlock(blockConnecting.vtx, pindexNew->nHeight);
     disconnectpool.removeForBlock(blockConnecting.vtx);
 
-
-    // VeriBlock: remove from pop_mempool
-    VeriBlock::removePayloadsFromMempool(blockConnecting.popData);
+    if (VeriBlock::isPopEnabled()) {
+        // VeriBlock: remove from pop_mempool
+        VeriBlock::removePayloadsFromMempool(blockConnecting.popData);
+    }
 
 
     // Update m_chain & related variables.
@@ -2648,7 +2669,7 @@ CBlockIndex* CChainState::FindBestChain()
 
         int popComparisonResult = 0;
 
-        if (Params().isPopActive(bestCandidate->nHeight)) {
+        if (VeriBlock::isPopEnabled() && Params().isPopActive(bestCandidate->nHeight)) {
             popComparisonResult = VeriBlock::compareForks(*bestCandidate, *pindexNew);
         } else {
             popComparisonResult = CBlockIndexWorkComparator()(bestCandidate, pindexNew) ? -1 : 1;
@@ -2890,16 +2911,19 @@ bool CChainState::ActivateBestChain(BlockValidationState& state, const CChainPar
                 // (with the exception of shutdown due to hardware issues, low disk space, etc).
                 ConnectTrace connectTrace(mempool); // Destructed before cs_main is unlocked
 
-                if (pblock && pindexBestChain == nullptr) {
-                    auto* blockindex = LookupBlockIndex(pblock->GetHash());
-                    assert(blockindex);
+                if (VeriBlock::isPopEnabled()) {
+                    if (pblock && pindexBestChain == nullptr) {
+                        auto* blockindex = LookupBlockIndex(pblock->GetHash());
+                        assert(blockindex);
 
-                    auto tmp_set = setBlockIndexCandidates;
-                    for (auto* candidate : tmp_set) {
-                        // if candidate has txs downloaded & currently arrived block is ancestor of `candidate`
-                        if (candidate->HaveTxsDownloaded() && TestBlockIndex(candidate) && candidate->GetAncestor(blockindex->nHeight) == blockindex) {
-                            // then do pop fr with candidate, instead of blockindex
-                            pindexBestChain = VeriBlock::compareTipToBlock(candidate);
+                        auto tmp_set = setBlockIndexCandidates;
+                        for (auto* candidate : tmp_set) {
+                            // if candidate has txs downloaded & currently arrived block is ancestor of `candidate`
+                            if (candidate->HaveTxsDownloaded() && TestBlockIndex(candidate) &&
+                                candidate->GetAncestor(blockindex->nHeight) == blockindex) {
+                                // then do pop fr with candidate, instead of blockindex
+                                pindexBestChain = VeriBlock::compareTipToBlock(candidate);
+                            }
                         }
                     }
                 }
@@ -3164,8 +3188,11 @@ void CChainState::ResetBlockFailureFlags(CBlockIndex* pindex)
     AssertLockHeld(cs_main);
 
     int nHeight = pindex->nHeight;
-    auto blockHash = pindex->GetBlockHash().asVector();
-    VeriBlock::GetPop().getAltBlockTree().revalidateSubtree(blockHash, altintegration::BLOCK_FAILED_BLOCK, false);
+
+    if (VeriBlock::isPopEnabled()) {
+        auto blockHash = pindex->GetBlockHash().asVector();
+        VeriBlock::GetPop().getAltBlockTree().revalidateSubtree(blockHash, altintegration::BLOCK_FAILED_BLOCK, false);
+    }
 
     // Remove the invalidity flag from this block and all its descendants.
     BlockMap::iterator it = m_blockman.m_block_index.begin();
@@ -3547,9 +3574,11 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-old", "block's timestamp is too early");
 
-    // Check timestamp
-    if (block.GetBlockTime() > nAdjustedTime + VeriBlock::GetPop().getConfig().getAltParams().maxAltchainFutureBlockTime())
-        return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
+    if (VeriBlock::isPopEnabled()) {
+        // Check timestamp
+        if (block.GetBlockTime() > nAdjustedTime + VeriBlock::GetPop().getConfig().getAltParams().maxAltchainFutureBlockTime())
+            return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
+    }
 
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
@@ -3739,8 +3768,10 @@ bool BlockManager::AcceptBlockHeader(const CBlockHeader& block, BlockValidationS
     if (ppindex)
         *ppindex = pindex;
 
-    if (!VeriBlock::acceptBlock(*pindex, state)) {
-        return error("%s: ALT tree could not accept block ALT:%d:%s, reason: %s", __func__, pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
+    if (VeriBlock::isPopEnabled()) {
+        if (!VeriBlock::acceptBlock(*pindex, state)) {
+            return error("%s: ALT tree could not accept block ALT:%d:%s, reason: %s", __func__, pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
+        }
     }
     return true;
 }
@@ -3848,7 +3879,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
         return error("%s: %s", __func__, FormatStateMessage(state));
     }
 
-    {
+    if (VeriBlock::isPopEnabled()) {
         if (!VeriBlock::addAllBlockPayloads(block, state)) {
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-block-pop-payloads",
                 strprintf("Can not add POP payloads to block height: %d , hash: %s: %s",
@@ -3935,26 +3966,28 @@ bool TestBlockValidity(BlockValidationState& state, const CChainParams& chainpar
     if (!ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindexPrev, fCheckMerkleRoot))
         return error("%s: Consensus::ContextualCheckBlock: %s", __func__, state.GetRejectReason());
 
-    // VeriBlock: Block that have been passed to TestBlockValidity may not exist in alt tree, because technically it was not created ("mined").
-    // in this case, add it and then remove
-    auto& tree = VeriBlock::GetPop().getAltBlockTree();
-    auto _hash = block_hash.asVector();
-    bool shouldRemove = false;
-    if (!tree.getBlockIndex(_hash)) {
-        shouldRemove = true;
-        auto containing = VeriBlock::blockToAltBlock(indexDummy);
-        altintegration::ValidationState _state;
-        bool ret = tree.acceptBlockHeader(containing, _state);
-        assert(ret && "alt tree can not accept alt block");
+    if (VeriBlock::isPopEnabled()) {
+        // VeriBlock: Block that have been passed to TestBlockValidity may not exist in alt tree, because technically it was not created ("mined").
+        // in this case, add it and then remove
+        auto& tree = VeriBlock::GetPop().getAltBlockTree();
+        auto _hash = block_hash.asVector();
+        bool shouldRemove = false;
+        if (!tree.getBlockIndex(_hash)) {
+            shouldRemove = true;
+            auto containing = VeriBlock::blockToAltBlock(indexDummy);
+            altintegration::ValidationState _state;
+            bool ret = tree.acceptBlockHeader(containing, _state);
+            assert(ret && "alt tree can not accept alt block");
 
-        tree.acceptBlock(_hash, block.popData);
-    }
-
-    auto _f = altintegration::Finalizer([shouldRemove, _hash, &tree]() {
-        if (shouldRemove) {
-            tree.removeSubtree(_hash);
+            tree.acceptBlock(_hash, block.popData);
         }
-    });
+
+        auto _f = altintegration::Finalizer([shouldRemove, _hash, &tree]() {
+            if (shouldRemove) {
+                tree.removeSubtree(_hash);
+            }
+        });
+    }
 
     if (!::ChainstateActive().ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
         return false;
@@ -4765,9 +4798,11 @@ bool CChainState::LoadGenesisBlock(const CChainParams& chainparams)
         if (blockPos.IsNull())
             return error("%s: writing genesis block to disk failed", __func__);
         CBlockIndex* pindex = m_blockman.AddToBlockIndex(block);
-        BlockValidationState state;
-        if (!VeriBlock::acceptBlock(*pindex, state)) {
-            return false;
+        if (VeriBlock::isPopEnabled()) {
+            BlockValidationState state;
+            if (!VeriBlock::acceptBlock(*pindex, state)) {
+                return false;
+            }
         }
         ReceivedBlockTransactions(block, pindex, blockPos, chainparams.GetConsensus());
     } catch (const std::runtime_error& e) {

--- a/src/vbk/merkle.cpp
+++ b/src/vbk/merkle.cpp
@@ -7,6 +7,7 @@
 #include <consensus/merkle.h>
 #include <hash.h>
 #include <vbk/pop_common.hpp>
+#include <vbk/pop_service.hpp>
 
 namespace VeriBlock {
 
@@ -19,6 +20,10 @@ uint256 TopLevelMerkleRoot(const CBlockIndex* prevIndex, const CBlock& block, bo
     auto txRoot = BlockMerkleRoot(block, mutated);
 
     // if POP is not enabled for 'block' , use original txRoot as merkle root
+    if (!VeriBlock::isPopEnabled()) {
+        return txRoot;
+    }
+
     const auto height = prevIndex == nullptr ? 0 : prevIndex->nHeight + 1;
     if (!Params().isPopActive(height)) {
         return txRoot;

--- a/src/vbk/params.hpp
+++ b/src/vbk/params.hpp
@@ -53,8 +53,8 @@ struct AltChainParamsVBTCDetRegTest : public altintegration::AltChainParams {
 
     AltChainParamsVBTCDetRegTest()
     {
-        bootstrap.hash = uint256S("22f15dd98c14badb8d58ec245a8539d86fa5344e984af023c8a7ea0316e24700").asVector();
-        // intentionally leave prevHash empty
+        bootstrap.hash = uint256S("393e1fea789a3ac750921d6d9f6aa7e84df9e031ecd63fca22dc3adc0632025c").asVector();
+        bootstrap.previousBlock = uint256S("42b16a400669ab1403410585e793cec350baa53ff3fddc2414be92f03f1b12f2").asVector();
         bootstrap.height = 1000;
         // intentionally leave timestamp empty
     }

--- a/src/vbk/params.hpp
+++ b/src/vbk/params.hpp
@@ -48,6 +48,40 @@ struct AltChainParamsVBTC : public altintegration::AltChainParams {
     altintegration::AltBlock bootstrap;
 };
 
+struct AltChainParamsVBTCDetRegTest : public altintegration::AltChainParams {
+    ~AltChainParamsVBTCDetRegTest() override = default;
+
+    AltChainParamsVBTCDetRegTest()
+    {
+        bootstrap.hash = uint256S("22f15dd98c14badb8d58ec245a8539d86fa5344e984af023c8a7ea0316e24700").asVector();
+        // intentionally leave prevHash empty
+        bootstrap.height = 1000;
+        // intentionally leave timestamp empty
+    }
+
+    altintegration::AltBlock getBootstrapBlock() const noexcept override
+    {
+        return bootstrap;
+    }
+
+    int64_t getIdentifier() const noexcept override
+    {
+        return 0x3ae6ca;
+    }
+
+    std::vector<uint8_t> getHash(const std::vector<uint8_t>& bytes) const noexcept override;
+
+    // we should verify:
+    // - check that 'bytes' can be deserialized to a CBlockHeader
+    // - check that this CBlockHeader is valid (time, pow, version...)
+    // - check that 'root' is equal to Merkle Root in CBlockHeader
+    bool checkBlockHeader(
+            const std::vector<uint8_t>& bytes,
+            const std::vector<uint8_t>& root, altintegration::ValidationState& state) const noexcept override;
+
+    altintegration::AltBlock bootstrap;
+};
+
 void printConfig(const altintegration::Config& config);
 void selectPopConfig(const std::string& network = "test");
 

--- a/src/vbk/pop_service.cpp
+++ b/src/vbk/pop_service.cpp
@@ -333,4 +333,21 @@ void addDisconnectedPopdata(const altintegration::PopData& popData) EXCLUSIVE_LO
     }
 }
 
+bool isPopEnabled()
+{
+    auto block = VeriBlock::GetPop().getConfig().getAltParams().getBootstrapBlock();
+    CBlockIndex* index;
+    {
+        LOCK(cs_main);
+        index = LookupBlockIndex(uint256(block.hash));
+    }
+    if (index == nullptr) {
+        return false;
+    }
+    if (index->nHeight == 0) {
+        return true;
+    }
+    return ChainActive().Contains(index);
+}
+
 } // namespace VeriBlock

--- a/src/vbk/pop_service.hpp
+++ b/src/vbk/pop_service.hpp
@@ -55,6 +55,8 @@ CAmount getCoinbaseSubsidy(const CAmount& subsidy, int32_t height, const CChainP
 
 void addDisconnectedPopdata(const altintegration::PopData& popData);
 
+bool isPopEnabled();
+
 } // namespace VeriBlock
 
 #endif //BITCOIN_SRC_VBK_POP_SERVICE_HPP

--- a/test/functional/feature_pop_enable.py
+++ b/test/functional/feature_pop_enable.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) 2019-2020 Xenios SEZC
+# https://www.veriblock.org
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+
+class PopEnable(BitcoinTestFramework):
+    def set_test_params(self):
+        self.chain = 'detregtest'
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_pypoptools()
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.nodes[0].setmocktime(1617025247)
+
+    def _check_pop_not_enabled(self):
+        current_height = self.nodes[0].getblockcount()
+        assert_raises_rpc_error(-1,
+                                'POP protocol is not enabled. Current={}, bootstrap height=1000'.format(current_height),
+                                self.nodes[0].getpopdatabyheight, current_height)
+
+    def _check_pop_enabled(self):
+        current_height = self.nodes[0].getblockcount()
+        self.nodes[0].getpopdatabyheight(current_height)
+
+    def _check_pop_not_active(self):
+        current_height = self.nodes[0].getblockcount()
+        assert_raises_rpc_error(-1,
+                                'POP protocol is not active. Current={}, activation height=1200'.format(current_height),
+                                self.nodes[0].submitpopvbk, self.vbk_block)
+
+    def _check_pop_active(self):
+        self.nodes[0].submitpopvbk(self.vbk_block)
+
+    def run_test(self):
+        from pypoptools.pypopminer import MockMiner
+        self.vbk_block = MockMiner().mineVbkBlocks(1).toVbkEncodingHex()
+
+        node = self.nodes[0]
+        mock_address = "bcrt1quc5k7w4692g0t0sfxc9xgcc25rzngu55zsfwp0"
+
+        # height 0
+        self._check_pop_not_enabled()
+
+        node.generatetoaddress(nblocks=100, address=mock_address)
+        # height 100
+        self._check_pop_not_enabled()
+
+        node.generatetoaddress(nblocks=400, address=mock_address)
+        # height 500
+        self._check_pop_not_enabled()
+
+        node.generatetoaddress(nblocks=499, address=mock_address)
+        # height 999
+        self._check_pop_not_enabled()
+
+        node.generatetoaddress(nblocks=1, address=mock_address)
+        # height 1000
+        self._check_pop_enabled()
+        self._check_pop_not_active()
+
+        node.generatetoaddress(nblocks=100, address=mock_address)
+        # height 1100
+        self._check_pop_enabled()
+        self._check_pop_not_active()
+
+        node.generatetoaddress(nblocks=99, address=mock_address)
+        # height 1199
+        self._check_pop_enabled()
+        self._check_pop_not_active()
+
+        node.generatetoaddress(nblocks=1, address=mock_address)
+        # height 1200
+        self._check_pop_enabled()
+        self._check_pop_active()
+
+
+if __name__ == '__main__':
+    PopEnable().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -116,6 +116,7 @@ BASE_SCRIPTS = [
     # VeriBlock tests
     'feature_pop_activate.py',
     'feature_pop_e2e.py',
+    'feature_pop_enable.py',
     'feature_pop_fork_resolution.py',
     'feature_pop_init.py',
     'feature_pop_mempool_getpop.py',


### PR DESCRIPTION
https://track.veriblock.org/issue/ALT-380
https://track.veriblock.org/issue/ALT-494
https://track.veriblock.org/issue/ALT-505

There are following changes:
- Guard function `isPopEnabled` and lots of checks for all POP-related actions.
- New network type `detregtest` and chain params for it.
- Call `altintegration::setMockTime` when `SetMockTime` is called.
- Functional test `feature_pop_enable`.