### PR TITLE
Fixed warning formatting and bitcoinFinality.

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -170,21 +170,21 @@ QString TransactionDesc::FormatBFIStatus(TransactionRecord *rec)
             }
         }
         else {
-            int spFinality = o.value("spFinality").toInt();
+            int bitcoinFinality = o.value("bitcoinFinality").toInt();
             bool isAttackInProgress = o.value("isAttackInProgress").toBool();
             
             if (isAttackInProgress) { 
                 vbkMessage = tr("Alternate Chain Detected, wait for Bitcoin Finality");
             }
             else {
-                if( spFinality >= 0 ) { 
+                if( bitcoinFinality >= 0 ) { 
                     vbkMessage = tr("%1 blocks of Bitcoin Finality");
-                    ++spFinality;
+                    ++bitcoinFinality;
                 } else { 
                     vbkMessage = tr("%1 blocks until Bitcoin Finality");
-                    spFinality = -spFinality;
+                    bitcoinFinality = -bitcoinFinality;
                 }
-                vbkMessage = vbkMessage.arg(QString::number(spFinality));
+                vbkMessage = vbkMessage.arg(QString::number(bitcoinFinality));
             }
         }
     } catch(...) { 

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -42,7 +42,7 @@ std::string GetWarnings(bool verbose)
 {
     std::string warnings_concise;
     std::string warnings_verbose;
-    const std::string warning_separator = "<hr />";
+    const std::string warning_separator = "<hr>";
 
     LOCK(cs_warnings);
 

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -14,7 +14,7 @@ bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);
 /** Format a string that describes several potential problems detected by the core.
  * @param[in] verbose bool
- * - if true, get all warnings, translated (where possible), separated by <hr />
+ * - if true, get all warnings, translated (where possible), separated by <hr>
  * - if false, get the most important warning
  * @returns the warning string
  */


### PR DESCRIPTION
The older hr tag without the end slash works. There are other places in the code that use the preferred format with a slash and I checked that those appear to work okay.
