### PR TITLE
Updated txid in test to match new genesis block.

### DIFF
--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -71,7 +71,7 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY(result == result2);
 
     RPCConsole::RPCExecuteCommandLine(*node, result, "getblock(getbestblockhash())[tx][0]", &filtered);
-    QVERIFY(result == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"); //this txid should be the first transaction within the genesis block
+    QVERIFY(result == "172a104def609f48532c3e4afbd9d9f530b7c359d031ac47d63191cb11ae56fe"); //this txid should be the first transaction within the genesis block
     QVERIFY(filtered == "getblock(getbestblockhash())[tx][0]");
 
     RPCConsole::RPCParseCommandLine(nullptr, result, "importprivkey", false, &filtered);

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -71,7 +71,7 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY(result == result2);
 
     RPCConsole::RPCExecuteCommandLine(*node, result, "getblock(getbestblockhash())[tx][0]", &filtered);
-    QVERIFY(result == "172a104def609f48532c3e4afbd9d9f530b7c359d031ac47d63191cb11ae56fe"); //this txid should be the first transaction within the genesis block
+    QVERIFY(result == "5c24f8481961119a2d73a84aef8fc32e839f35cb8407455d37a8efc37e9e915a"); //this txid should be the first transaction within the genesis block
     QVERIFY(filtered == "getblock(getbestblockhash())[tx][0]");
 
     RPCConsole::RPCParseCommandLine(nullptr, result, "importprivkey", false, &filtered);


### PR DESCRIPTION
Replaced hardcoded transaction id in test with updated value.
