### PR TITLE
:bug: Builds breaking on new cmake release, unable to install latest cmake into ubuntu 18.

### DIFF
--- a/ubuntu-asan.Dockerfile
+++ b/ubuntu-asan.Dockerfile
@@ -3,7 +3,7 @@ FROM veriblock/prerelease-btc
 ADD . /app
 WORKDIR /app
 
-RUN pip3 install cmake
+RUN pip3 install cmake==3.16.8
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -4,7 +4,7 @@ ADD . /app
 WORKDIR /app
 ARG BUILD_TYPE=Release
 
-RUN pip3 install cmake
+RUN pip3 install cmake==3.16.8
 
 ENV BUILD=${BUILD_TYPE}
 RUN export VERIBLOCK_POP_CPP_VERSION=$(awk -F '=' '/\$\(package\)_version/{print $NF}' $PWD/depends/packages/veriblock-pop-cpp.mk | head -n1); \


### PR DESCRIPTION
We need to maintain what version we're using in the Dockerfile so we do not have this issue in the future. I'm locking the cmake pip3 version to `3.16.8`.